### PR TITLE
IMU improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
-.vscode/extensions.json
+.vscode-server
+.devcontainer


### PR DESCRIPTION
Changes IMU mode to OPERATION_MODE_IMUPLUS - by default it was set to NDOF, which also used magnetometer and orientation quality wasn't too good. With this change, even without calibration, orientation is much better.

Adds angular velocity conversion to rad/s. 